### PR TITLE
Fixed incorrect heading range. Fixed wrong acceleration sent from Sm to FC

### DIFF
--- a/src/fc_serial.cpp
+++ b/src/fc_serial.cpp
@@ -702,6 +702,14 @@ void FC_Serial::FeedBytes(QByteArray data)
         serialMSPreceive(data[i]);
 }
 
+float wrap_3600(float angle)
+{
+    if (angle > 3600)
+        angle -= 3600;
+    if (angle < 0)
+        angle += 3600;
+    return angle;
+}
 
 void FC_Serial::sendDatagram(const simToPlugin *stp)
 {
@@ -721,18 +729,18 @@ void FC_Serial::sendDatagram(const simToPlugin *stp)
         }
     }
 
-    telem.X = stp->accelX/9.810*-1000;
-    telem.Y = stp->accelY/9.810*-1000;
-    telem.Z = stp->accelZ/9.810*1000+1000;
+    telem.X = stp->accelXm/9.810*-1000;
+    telem.Y = stp->accelYm/9.810*-1000;
+    telem.Z = stp->accelZm/9.810*1000+1000;
     telem.Roll = -stp->roll*RAD2DEG*10;
     telem.Pitch = -stp->pitch*RAD2DEG*10;
-    telem.Yaw = stp->heading*RAD2DEG*10;
+    telem.Yaw = wrap_3600(stp->heading*RAD2DEG*10);
     telem.baroaltitude = stp->AGL*100;
     telem.GPS_latitude = stp->latitude*10e6;
     telem.GPS_longitude = stp->longitude*10e6;
     telem.GPS_altitude = stp->AGL;
     telem.GPS_speed = sqrt(pow(stp->velX,2) + pow(stp->velY,2))*100;
-    telem.MwHeading = stp->heading*RAD2DEG*10;
+    telem.MwHeading = wrap_3600(stp->heading*RAD2DEG*10);
     telem.GPS_numSat = 10;
 
 

--- a/src/plugin.pro
+++ b/src/plugin.pro
@@ -11,8 +11,8 @@ TARGET = plugin_AeroSIMRC
 copydata = 1
 
 RES_DIR    = $${PWD}/resources
-SIM_DIR    = "c:/qt2/AeroSIMRC_4.20-0.0_b743"
-PLUGIN_DIR = "c:/qt2/AeroSIMRC_4.20-0.0_b743/Plugin/CleanFlight"
+SIM_DIR    = "C:/CF_HIL/AeroSIM-RC"
+PLUGIN_DIR = "C:/CF_HIL/AeroSIM-RC/Plugin/CleanFlight"
 DLLDESTDIR = $$PLUGIN_DIR
 
 defineReplace(targetPath) {


### PR DESCRIPTION
CF IMU expects heading to be in 0..360 deg range, Sim was reporting -180..+180 range. 
Sim was reporting acceleration in Earth frame, IMU needs body frame.
